### PR TITLE
add the ability to pass in labels that will be skipped

### DIFF
--- a/bin/close-some-stale-issues.js
+++ b/bin/close-some-stale-issues.js
@@ -66,6 +66,12 @@ require('machine-as-script')({
         description: 'How many days of inactivity to allow before an issue is considered stale.',
         example: 30,
         defaultsTo: 30
+      },
+
+      labelsToExclude: {
+        description: 'A set of issue labels.',
+        extendedDescription: 'Issues that include _none_ of these labels will be included in search results.',
+        example: ['bug']
       }
 
     },
@@ -106,6 +112,7 @@ require('machine-as-script')({
           state: 'open',
           lastUpdatedBefore: lastUpdatedBefore,
           credentials: inputs.credentials,
+          withNoneOfTheseLabels: inputs.labelsToExclude
         }).exec({
           error: function (err) {
             // If an error was encountered, keep going, but log it to the console.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "async": "^1.4.2",
     "lodash": "^3.10.1",
     "machine-as-script": "^2.0.1",
-    "machinepack-github": "^4.1.1"
+    "machinepack-github": "^4.2.0"
   },
   "scripts": {
     "start": "node bin/boatswain.js"


### PR DESCRIPTION
Allows for labels such as `bug` to be passed in when closing stale issues so that they will be skipped.

Fixes #1 